### PR TITLE
Remove unnecessary onBlocksRegistry event

### DIFF
--- a/src/main/java/com/lgmrszd/compressedcreativity/CompressedCreativity.java
+++ b/src/main/java/com/lgmrszd/compressedcreativity/CompressedCreativity.java
@@ -99,18 +99,6 @@ public class CompressedCreativity
 //        LOGGER.info("HELLO from server starting");
 //    }
 
-    // You can use EventBusSubscriber to automatically subscribe events on the contained class (this is subscribing to the MOD
-    // Event bus for receiving Registry Events)
-    @Mod.EventBusSubscriber(bus=Mod.EventBusSubscriber.Bus.MOD)
-    public static class RegistryEvents {
-        @SubscribeEvent
-        public static void onBlocksRegistry(final RegistryEvent.Register<Block> blockRegistryEvent) {
-            // register a new block here
-            LOGGER.info("HELLO from Register Block");
-        }
-    }
-
-
     public void postInit(FMLLoadCompleteEvent evt) {
         int i = 0;
         Network.registerMessage(i++, ObservePacket.class, ObservePacket::encode, ObservePacket::decode, ObservePacket::handle);


### PR DESCRIPTION
The pull request just removes the unnecessary onBlocksRegistry event from [CompressedCreativity.java](https://github.com/Lgmrszd/CompressedCreativity/compare/1.18.2...OutCraft-Mods:CompressedCreativity:patch-1#diff-e0d4ba60aa680d58f220fb5aa9d3be7b0d7b67da95c0d3e26a22853c63ee77cb)